### PR TITLE
Field.type depricated in coreapi in favour of schema

### DIFF
--- a/raml_codec/encode.py
+++ b/raml_codec/encode.py
@@ -1,4 +1,5 @@
 import yaml
+from coreapi.codecs.corejson import SCHEMA_CLASS_TO_TYPE_ID
 
 
 def get_resources(node, keys=()):
@@ -19,11 +20,21 @@ def get_resources(node, keys=()):
     return resources
 
 
+def get_type_string(field):
+    field_type = getattr(field, 'type', None)
+    field_schema = getattr(field, 'schema', None)
+
+    if field_type is not None:
+        return field_type
+    else:
+        SCHEMA_CLASS_TO_TYPE_ID.get(field_schema.__class__, 'anything')
+
+
 def get_params(fields):
     return {
         field.name: {
             'description': field.description,
-            'type': field.type,
+            'type': get_type_string(field),
             'required': field.required
         } for field in fields
     }

--- a/raml_codec/encode.py
+++ b/raml_codec/encode.py
@@ -27,7 +27,7 @@ def get_type_string(field):
     if field_type is not None:
         return field_type
     else:
-        SCHEMA_CLASS_TO_TYPE_ID.get(field_schema.__class__, 'anything')
+        return SCHEMA_CLASS_TO_TYPE_ID.get(field_schema.__class__, 'anything')
 
 
 def get_params(fields):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrs==16.2.0
 click==6.6
-coreapi==2.0.8
+coreapi==2.2.4
 coverage==4.2
 flake8==3.0.4
 itypes==1.1.0


### PR DESCRIPTION
Get the field type by first checking if there's a field.type, or if no field.type, using the coreapi SCHEMA_CLASS_TO_TYPE_ID mapping to map the schema object.

Bump the coreapi version to 2.2.4 to get access to SCHEMA_CLASS_TO_TYPE_ID.

This seems to be the source of this issue (https://github.com/tomchristie/django-rest-raml/issues/9), as type is None, the output then contains ```type: none``` which doesn't appear to be valid RAML. 

I'm not sure if defaulting to ```anything``` is correct, and maybe as type is depricated, that should be fallback, not the first thing checked?